### PR TITLE
add power-overwhelming repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ TODO
 ## Tutorials
 
 * [DragonRuby Game Toolkit Tutorial](http://dragonruby.school) by Lori M Olson
+* [Intro to DragonRuby Game Toolkit](https://www.youtube.com/watch?v=DYBRzglsEzU) by Ryan C Gordon
 
 ## Other Resources
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ TODO
 ## Other Resources
 
 * [dragon-ruby-documenter](https://github.com/ediathome/dragon-ruby-documenter) - This small app dumps a basic DragonRuby documentation to a Markdown file.
+* [power-overwhelming](https://github.com/amirrajan/power-overwhelming) - A github repo used by Amir Rajan for his presentation at RubyKaigi 2019.
 
 ## Community Resources
 * [@rubymotion on Twitter](https://twitter.com/rubymotion)


### PR DESCRIPTION
Add a link to a github repo used by Amir Rajan for his presentation at RubyKaigi 2019.