### PR TITLE
Add link to the API documentation effort

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Please take a look at the [contribution guidelines and quality standard](https:/
 ### Documents
 
 * [DragonRubyObjectMethods](https://vtlearn.de/site/dragonruby/)
+* [DragonRuby API Documentation](https://pusewicz.github.io/dragon-ruby-gtk-docs/index.html)
 
 ### Courses
 


### PR DESCRIPTION
This PR adds the link to the documentation efforts for the Game Toolkit API.